### PR TITLE
Fix tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,7 +42,7 @@ def test_create_manifestation(client, user):
             'isManifestation': True,
         },
         'copyright': {
-            '@context': '<coalaip placeholder>',
+            '@context': ['<coalaip placeholder>', 'http://schema.org/'],
             '@type': 'Copyright',
             '@id': '',
         },
@@ -108,7 +108,7 @@ def test_create_right(client, user):
 
     expected = {
         'right': {
-            '@context': '<coalaip placeholder>',
+            '@context': ['<coalaip placeholder>', 'http://schema.org/'],
             '@type': 'Right',
             '@id': '',
             'allowedBy': payload['sourceRightId'],


### PR DESCRIPTION
https://github.com/bigchaindb/coalaip-http-api/blob/master/setup.py#L7 uses `pycoalaip == 0.0.1.dev3` automatically, which causes tests to fail currently.


This fixes (hopefully) the tests :pray:.