### PR TITLE
Upgrade BigchainDB Server to 0.9 and COALA IP-related dependencies

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -8,7 +8,6 @@ API_PORT=3000
 # Settings for the BigchainDB node that the API server should connect to
 BDB_NODE_HOST=
 BDB_NODE_PORT=
-BDB_NODE_API_PATH=
 
 ##### Docker settings #####
 # Externally exposed port for accessing BigchainDB's API

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 before_script:
   - rethinkdb --daemon
-  - bigchaindb -y configure
+  - bigchaindb -y configure rethinkdb
   # Start BigchainDB in the background and ignore any output
   - bigchaindb start >/dev/null 2>&1 &
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The API server can be configured with a number of environment variables [see
 ### Create Users
 
 This call will not store any data on the running instance of BigchainDB.
-It simply generates a verifying and signing key-pair that can be used in a
+It simply generates a public/private key-pair that can be used in a
 POST-manifestation call.
 
 ```
@@ -151,8 +151,8 @@ PAYLOAD: None
 
 RETURNS:
 {
-    "verifyingKey": "<base58 string>",
-    "signingKey": "<base58 string>",
+    "publicKey": "<base58 string>",
+    "privateKey": "<base58 string>",
 }
 ```
 
@@ -160,8 +160,8 @@ RETURNS:
 ### Register a Manifestation
 
 In order to register the manifestation on BigchainDB as transactions on a
-specific copyright holder's name, the copyright holder's `verifyingKey` and
-`signingKey` must be provided here.
+specific copyright holder's name, the copyright holder's `publicKey` and
+`privateKey` must be provided here.
 
 Note that the attributes shown for `manifestation` and `work` can be much more
 diverse; for this, see their [COALA IP models definition](https://github.com/COALAIP/specs/tree/master/data-structure#rrm-creation).
@@ -178,8 +178,8 @@ PAYLOAD:
         "url": "<URI pointing to a media blob>"
     },
     "copyrightHolder": {
-        "verifyingKey": "<base58 string>",
-        "signingKey": "<base58 string>"
+        "publicKey": "<base58 string>",
+        "privateKey": "<base58 string>"
     },
     "work": {
         "name": "The Lord of the Rings Triology",
@@ -277,8 +277,8 @@ PAYLOAD:
         "license": "<Legal license text or URI pointing to a license document>"
     },
     "currentHolder": {
-        "verifyingKey": "<base58 string>",
-        "signingKey": "<base58 string>"
+        "publicKey": "<base58 string>",
+        "privateKey": "<base58 string>"
     },
     "sourceRightId": "<ID of an existing Right that allows for the creation of this new Right>"
 }

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ RETURNS:
 {
     "work": {
         "@id": "<Relative URI with the ID of the entity on BigchainDB>",
-        "@type": "CreativeWork",
+        "@type": "AbstractWork",
         "name": "The Lord of the Rings Trilogy",
         "author": "J. R. R. Tolkien"
     },
@@ -202,8 +202,7 @@ RETURNS:
         "name": "The Fellowship of the Ring",
         "manifestationOfWork": "<URI pointing to the Work's transaction ../<txid>",
         "datePublished": "29-07-1954",
-        "url": "<URI pointing to a media blob>",
-        "isManifestation": true
+        "url": "<URI pointing to a media blob>"
     },
     "copyright": {
         "@id": "<Relative URI with the ID of the entity on BigchainDB>",
@@ -288,7 +287,7 @@ RETURNS:
     "right": {
         "@id": "<Relative URI with the ID of the entity on BigchainDB>",
         "@type": "Right",
-        "allowedBy": <The sourceRightId>,
+        "source": "<sourceRightId>",
         "license": "<Legal license text or URI pointing to a license document>",
     }
 }

--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ part of the new Right's chain of provenance.
 Note that the attributes for the `right` may be much more diverse; see its [COALA
 IP models definition](https://github.com/COALAIP/specs/tree/master/data-structure#rrm-right).
 
-Also see transferring a Right on how to transfer a registered Right to new
-holders.
+Also see [transferring a Right](#transfer-a-right) on how to transfer a
+registered Right to new holders.
 
 ```
 POST /api/v1/rights/

--- a/compose/api/Dockerfile
+++ b/compose/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5
 
-RUN apt-get update && apt-get install -y vim
+RUN apt-get update
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -9,4 +9,4 @@ RUN pip install --upgrade pip
 
 COPY . /usr/src/app/
 
-RUN pip install --no-cache-dir --process-dependency-links -e .
+RUN pip install --no-cache-dir --process-dependency-links -r requirements_dev.txt

--- a/compose/bigchaindb/Dockerfile
+++ b/compose/bigchaindb/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /usr/src/app
 RUN pip install --upgrade pip
 
 RUN pip install bigchaindb
-RUN bigchaindb -y configure
+RUN bigchaindb -y configure rethinkdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - .env
     environment:
       API_HOST: api
-      BDB_NODE_HOST: "${BDB_NODE_HOST}"
-      BDB_NODE_PORT: "${BDB_NODE_PORT}"
+      BDB_NODE_HOST: bigchaindb
+      BDB_NODE_PORT: 9984
     ports:
       - "${API_PORT}:3000"
     command: python web/server.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==8.1.2
+pip==9.0.1
 bumpversion==0.5.3
 wheel==0.29.0
 

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    'coalaip>=0.0.1.dev3',
-    'coalaip-bigchaindb>=0.0.1.dev3',
+    'coalaip==0.0.1',
+    'coalaip-bigchaindb==0.0.1',
     'bigchaindb~=0.9.1',
     'flask>=0.11.1',
     'flask-restful>=0.3.5',

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ from setuptools import setup, find_packages
 install_requires = [
     'coalaip>=0.0.1.dev3',
     'coalaip-bigchaindb>=0.0.1.dev3',
-    'bigchaindb==0.8.0',
-    'bigchaindb-driver==0.1.2',
+    'bigchaindb~=0.9.1',
     'flask>=0.11.1',
     'flask-restful>=0.3.5',
     'gunicorn>=19.6.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,29 @@ def app():
 @pytest.fixture
 def user(client):
     return client.post(url_for('user_views.userapi')).json
+
+
+@pytest.fixture
+def created_manifestation_resp(client, user):
+    import json
+    from time import sleep
+    payload = {
+        'manifestation': {
+            'name': 'The Fellowship of the Ring',
+            'datePublished': '29-07-1954',
+            'url': 'http://localhost/lordoftherings.txt',
+        },
+        'copyrightHolder': user,
+        'work': {
+            'name': 'The Lord of the Rings Triology',
+            'author': 'J. R. R. Tolkien',
+        },
+    }
+
+    resp = client.post(url_for('manifestation_views.manifestationapi'),
+                       data=json.dumps(payload),
+                       headers={'Content-Type': 'application/json'})
+
+    # Sleep for a bit to let the transaction become valid
+    sleep(3)
+    return resp.json

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,8 @@ from flask import url_for
 def test_create_user(client):
     resp = client.post(url_for('user_views.userapi'))
     assert resp.status_code == 200
-    assert resp.json['verifyingKey']
-    assert resp.json['signingKey']
+    assert resp.json['publicKey']
+    assert resp.json['privateKey']
 
 
 def test_create_manifestation(client, user):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,7 +27,7 @@ def test_create_manifestation(client, user):
     expected = {
         'work': {
             '@context': ['<coalaip placeholder>', 'http://schema.org/'],
-            '@type': 'CreativeWork',
+            '@type': 'AbstractWork',
             'name': 'The Lord of the Rings Triology',
             'author': 'J. R. R. Tolkien',
         },
@@ -37,7 +37,6 @@ def test_create_manifestation(client, user):
             'name': 'The Fellowship of the Ring',
             'datePublished': '29-07-1954',
             'url': 'http://localhost/lordoftherings.txt',
-            'isManifestation': True,
         },
         'copyright': {
             '@context': ['<coalaip placeholder>', 'http://schema.org/'],
@@ -122,7 +121,7 @@ def test_create_right(client, user):
         'right': {
             '@context': ['<coalaip placeholder>', 'http://schema.org/'],
             '@type': 'Right',
-            'allowedBy': payload['sourceRightId'],
+            'source': payload['sourceRightId'],
             'license': 'http://www.ascribe.io/terms',
         }
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,13 +108,16 @@ def test_create_manifestation_missing_argument_in_body(client):
         'Missing required parameter in the JSON body'
 
 
-def test_create_right(client, user):
+def test_create_right(client, user, created_manifestation_resp):
+    copyright_id = created_manifestation_resp['copyright']['@id']
+    copyright_id = copyright_id.split('../rights/')[1]
+
     payload = {
         'currentHolder': user,
         'right': {
             'license': 'http://www.ascribe.io/terms',
         },
-        'sourceRightId': 'mockId',
+        'sourceRightId': copyright_id,
     }
 
     expected = {

--- a/web/models.py
+++ b/web/models.py
@@ -1,7 +1,7 @@
 from web.utils import parse_model
 
 
-user_model = parse_model(['verifyingKey', 'signingKey'])
+user_model = parse_model(['publicKey', 'privateKey'])
 manifestation_model = parse_model(['name', 'datePublished', 'url'])
 work_model = parse_model(['name', 'author'])
 right_model = parse_model(['license'])

--- a/web/utils.py
+++ b/web/utils.py
@@ -5,7 +5,6 @@ import os
 BigchainDBConfiguration = namedtuple('BigchainDBConfiguration', [
     'hostname',
     'port',
-    'api_path'
 ])
 
 
@@ -19,20 +18,14 @@ BDB_PORT = os.environ.get('BDB_NODE_PORT', None)
 if not BDB_PORT:
     BDB_PORT = '9984'
 
-BDB_API_PATH = os.environ.get('BDB_NODE_API_PATH', None)
-if not BDB_API_PATH:
-    BDB_API_PATH = 'api/v1'
-
 
 def get_bigchaindb_configuration():
-    return BigchainDBConfiguration(BDB_HOST, BDB_PORT, BDB_API_PATH)
+    return BigchainDBConfiguration(BDB_HOST, BDB_PORT)
 
 
 def get_bigchaindb_api_url():
-    hostname, port, api_path = get_bigchaindb_configuration()
-    return 'http://{hostname}:{port}/{api_path}'.format(hostname=hostname,
-                                                        port=port,
-                                                        api_path=api_path)
+    hostname, port = get_bigchaindb_configuration()
+    return 'http://{hostname}:{port}'.format(hostname=hostname, port=port)
 
 
 def parse_model(required_fields):

--- a/web/views/manifestations.py
+++ b/web/views/manifestations.py
@@ -29,8 +29,8 @@ class ManifestationApi(Resource):
 
         copyright_holder = args['copyrightHolder']
         copyright_holder = {
-            'verifying_key': copyright_holder.pop('verifyingKey'),
-            'signing_key': copyright_holder.pop('signingKey')
+            'public_key': copyright_holder.pop('publicKey'),
+            'private_key': copyright_holder.pop('privateKey')
         }
 
         copyright_, manifestation, work = coalaip.register_manifestation(

--- a/web/views/rights.py
+++ b/web/views/rights.py
@@ -29,8 +29,8 @@ class RightApi(Resource):
         right['allowedBy'] = source_right_id
 
         current_holder = args['currentHolder']
-        current_holder['verifying_key'] = current_holder.pop('verifyingKey')
-        current_holder['signing_key'] = current_holder.pop('signingKey')
+        current_holder['public_key'] = current_holder.pop('publicKey')
+        current_holder['private_key'] = current_holder.pop('privateKey')
 
         right = coalaip.derive_right(right_data=right,
                                      current_holder=current_holder)

--- a/web/views/rights.py
+++ b/web/views/rights.py
@@ -26,7 +26,7 @@ class RightApi(Resource):
 
         source_right_id = args['sourceRightId']
         right = args['right']
-        right['allowedBy'] = source_right_id
+        right['source'] = source_right_id
 
         current_holder = args['currentHolder']
         current_holder['public_key'] = current_holder.pop('publicKey')

--- a/web/views/users.py
+++ b/web/views/users.py
@@ -17,13 +17,13 @@ class UserApi(Resource):
         """API endpoint to create a new keypair for a user
 
         Return:
-            A dict containing the verifying_key and signing_key.
+            A dict containing the publicKey and privateKey.
         """
         # TODO FOR COALA IP: Return CamelCase key names
         user = coalaip.generate_user()
         # TODO: We might want to have a generic function for this at one point.
-        user['verifyingKey'] = user.pop('verifying_key')
-        user['signingKey'] = user.pop('signing_key')
+        user['publicKey'] = user.pop('public_key')
+        user['privateKey'] = user.pop('private_key')
         return user
 
 


### PR DESCRIPTION
Adds dependency links until new versions of `pycoalaip` and `pycoalaip-bigchaindb` are released.

TODO:

* [x] Remove dependency links and drop https://github.com/bigchaindb/coalaip-http-api/pull/25/commits/8adaae92bd6df5ab9ef9cbcb1d4d7381940c459c once [transfers](https://github.com/bigchaindb/coalaip-http-api/pull/17) and entity history look ups are implemented