### PR TITLE
Add support for GETing entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ To check if your POST was successful, try validating by doing the following:
 
 or
 
+1. Try to [request for the entity with a GET request](#requesting-submitted-entities)
+
+or
+
 1. Open your browser and go to `http://localhost:9984/api/v1` (your locally
    running BigchainDB instance - if using the default Docker settings, use port
    `32768` instead).
@@ -364,6 +368,17 @@ conform to the [user model](#create-users).
 To check if your POST was successful, follow the steps in [registering a
 manifestation](#was-my-post-to-manifestations-successful) and use the returned
 Right's data instead.
+
+
+### Requesting Submitted Entities
+
+You can retrieve any submitted entities via a GET to one of the following
+endpoints with the entity's ID (usually the `@id` stripped of any relative URL
+artifacts):
+
+* `/manifestations/<manifestation_id>`: Manifestations
+* `/works/<work_id>`: Works
+* `/rights/<right_id>`: Copyrights and Rights
 
 
 ### Querying the ownership history of a Right

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def created_manifestation_resp(client, alice):
         },
     }
 
-    resp = client.post(url_for('manifestation_views.manifestationapi'),
+    resp = client.post(url_for('manifestation_views.manifestationlistapi'),
                        data=json.dumps(payload),
                        headers={'Content-Type': 'application/json'})
 
@@ -66,7 +66,7 @@ def created_derived_right(client, alice, created_manifestation_resp):
         'sourceRightId': copyright_id,
     }
 
-    resp = client.post(url_for('right_views.rightapi'),
+    resp = client.post(url_for('right_views.rightlistapi'),
                        data=json.dumps(payload),
                        headers={'Content-Type': 'application/json'})
 

--- a/web/server.py
+++ b/web/server.py
@@ -15,6 +15,7 @@ from flask_cors import CORS
 from web.views.users import user_views
 from web.views.manifestations import manifestation_views
 from web.views.rights import right_views
+from web.views.works import work_views
 
 
 class StandaloneApplication(gunicorn.app.base.BaseApplication):
@@ -67,6 +68,7 @@ def create_app(settings):
     app.register_blueprint(user_views, url_prefix='/api/v1')
     app.register_blueprint(manifestation_views, url_prefix='/api/v1')
     app.register_blueprint(right_views, url_prefix='/api/v1')
+    app.register_blueprint(work_views, url_prefix='/api/v1')
     return app
 
 

--- a/web/views/manifestations.py
+++ b/web/views/manifestations.py
@@ -1,7 +1,7 @@
 from flask import Blueprint
 from flask_restful import reqparse, Resource, Api
 
-from coalaip import CoalaIp
+from coalaip import CoalaIp, entities
 from coalaip_bigchaindb.plugin import Plugin
 from web.models import manifestation_model, user_model, work_model
 from web.utils import get_bigchaindb_api_url
@@ -14,6 +14,13 @@ manifestation_api = Api(manifestation_views)
 
 
 class ManifestationApi(Resource):
+    def get(self, entity_id):
+        manifestation = entities.Manifestation.from_persist_id(
+            entity_id, plugin=coalaip.plugin, force_load=True)
+        return manifestation.to_jsonld()
+
+
+class ManifestationListApi(Resource):
     def post(self):
         parser = reqparse.RequestParser()
         parser.add_argument('manifestation', type=manifestation_model,
@@ -51,5 +58,7 @@ class ManifestationApi(Resource):
         return res
 
 
-manifestation_api.add_resource(ManifestationApi, '/manifestations',
+manifestation_api.add_resource(ManifestationApi, '/manifestations/<entity_id>',
+                               strict_slashes=False)
+manifestation_api.add_resource(ManifestationListApi, '/manifestations',
                                strict_slashes=False)

--- a/web/views/works.py
+++ b/web/views/works.py
@@ -1,0 +1,22 @@
+from flask import Blueprint
+from flask_restful import Resource, Api
+
+from coalaip import CoalaIp, entities
+from coalaip_bigchaindb.plugin import Plugin
+from web.utils import get_bigchaindb_api_url
+
+
+coalaip = CoalaIp(Plugin(get_bigchaindb_api_url()))
+
+work_views = Blueprint('work_views', __name__)
+work_api = Api(work_views)
+
+
+class WorkApi(Resource):
+    def get(self, entity_id):
+        work = entities.Work.from_persist_id(
+            entity_id, plugin=coalaip.plugin, force_load=True)
+        return work.to_jsonld()
+
+
+work_api.add_resource(WorkApi, '/work/<entity_id>', strict_slashes=False)


### PR DESCRIPTION
Fixes #14.

Builds on #27.

Adds support for retrieving entities (by their ID) for `Work`s, `Manifestation`s, `Copyright`s, and `Right`s.